### PR TITLE
added docs

### DIFF
--- a/release-notes/major9/09.19.0/valtimo-backend-libraries.md
+++ b/release-notes/major9/09.19.0/valtimo-backend-libraries.md
@@ -19,9 +19,10 @@ The following features were added:
 
 The following bugs were fixed:
 
-* **Bug1**
+* **JdbcProcessFormAssociationRepository insert statement runtime exception**
 
-  Description of what the issue was.
+  Running on an externally hosted Mysql 8.0.15 instance caused unknown column type exceptions with useServerPrepStmts [see](https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration).
+  To prevent determining the sql column type now the type is specified.
 
 * **Bug2**
 


### PR DESCRIPTION
* **JdbcProcessFormAssociationRepository insert statement runtime exception**

  Running on an externally hosted Mysql 8.0.15 instance caused unknown column type exceptions with useServerPrepStmts [see](https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration).
  To prevent determining the sql column type now the type is specified.