### PR TITLE
Documentation for deprecated FormFieldDataResolver get method

### DIFF
--- a/release-notes/major9/09.21.0/migration.md
+++ b/release-notes/major9/09.21.0/migration.md
@@ -2,20 +2,21 @@
 
 This page describes how to update Valtimo from the previous version to the current.
 
-* **Breaking change 1/Deprecation 1**
+* **FormFieldDataResolver `get` method is deprecated**
 
-  1. **Step1**
+  1. **Implement the new `get` method**
 
-     Description
-  2. **Step2**
+      Add method `get(String documentDefinitionName, UUID documentId, JsonNode formDefinition, String... varNames)` to your class and move the logic from the deprecated `get` to this new method
 
-     Description
+  2. **Invoke new `get` from deprecated `get`**  
 
-* **Breaking change 2/Deprecation 2**
-
-  1. **Step1**
-
-      Description
-  2. **Step2**
-
-      Description
+      ```
+      override fun get(documentDefinitionName: String, documentId: UUID, vararg varNames: String): Map<String, Any> {
+          return get(
+              documentDefinitionName = documentDefinitionName,
+              documentId = documentId,
+              formDefinition = Mapper.INSTANCE.get().createObjectNode(),
+              varNames = varNames
+          )
+      }
+      ```

--- a/release-notes/major9/09.21.0/valtimo-backend-libraries.md
+++ b/release-notes/major9/09.21.0/valtimo-backend-libraries.md
@@ -40,9 +40,10 @@ Instructions on how to migrate to this version of Valtimo can be found [here](mi
 
 The following was deprecated:
 
-* **Deprecation1**
+* **FormFieldDataResolver `get` method**
 
-  X was deprecated and is replaced with Y.
+  The method `get(String documentDefinitionName, UUID documentId, String... varNames)` was deprecated and \
+  is replaced with `get(String documentDefinitionName, UUID documentId, JsonNode formDefinition, String... varNames)`.
 
 * **Deprecation2**
 


### PR DESCRIPTION
Added details about the deprecation of the get method in FormFieldDataResolver and how to migrate to new version