### PR TITLE
38923: Added release notes for user-management page warning

### DIFF
--- a/release-notes/major9/09.23.0/valtimo-frontend-libraries.md
+++ b/release-notes/major9/09.23.0/valtimo-frontend-libraries.md
@@ -39,8 +39,11 @@ The following features were added:
     ]
   }
   ```
-  
 
+* **Added warning message to user management page**
+
+  On the user management page an admin can now see a warning message that notifies them about the fact that user management is handled separately in Keycloak in case Keycloak is used for IAM. The message can be customized by using the translation key `User management not supported`.
+  
 ## Bugfixes
 
 The following bugs were fixed:

--- a/release-notes/major9/09.23.0/valtimo-frontend-libraries.md
+++ b/release-notes/major9/09.23.0/valtimo-frontend-libraries.md
@@ -42,7 +42,9 @@ The following features were added:
 
 * **Added warning message to user management page**
 
-  On the user management page an admin can now see a warning message that notifies them about the fact that user management is handled separately in Keycloak in case Keycloak is used for IAM. The message can be customized by using the translation key `User management not supported`.
+  In case Keycloak is used for IAM, the user management page now shows a warning message stating that user management is only supported within Keycloak. 
+  
+  The message can be customized by using the translation key `userManagement.notSupported`.
   
 ## Bugfixes
 


### PR DESCRIPTION
Added an explanation on the warning message that was added including the respective translation key