### PR TITLE
Moved the flatpickr dependency information  to the migration notes

### DIFF
--- a/release-notes/major9/09.21.0/migration.md
+++ b/release-notes/major9/09.21.0/migration.md
@@ -10,3 +10,22 @@ This page describes how to update Valtimo from the previous version to the curre
      
       Add method `get(DataResolvingContext dataResolvingContext, String... varNames)` to your class and move the logic from the deprecated `get` to this new method. 
       The parameters `String documentDefinitionName` and `UUID documentId` are moved to the `DataResolvingContext` object. 
+
+
+* **New datepicker component flatpickr**
+    
+  Scope: frontend
+
+  If this component is included anywhere in an implementation:
+
+  1. **Install flatpickr dependency**
+  
+      Run `npm install flatpickr` to install the dependency. 
+      
+      When upgrading to [Valtimo frontend libraries 5.12.0](/release-notes/major9/09.23.0/valtimo-frontend-libraries.md)
+      this is no longer necessary as the dependency is included in the libraries.
+  
+  2. **Add style to angular.json**
+
+      Add `"node_modules/flatpickr/dist/flatpickr.css"` to the styles array in `angular.json` to avoid issues.
+      

--- a/release-notes/major9/09.21.0/valtimo-frontend-libraries.md
+++ b/release-notes/major9/09.21.0/valtimo-frontend-libraries.md
@@ -39,9 +39,8 @@ The following features were added:
 * **New datepicker component**
 
   Added a new date picker component to `@valtimo/user-interface`: `v-date-picker`. It is based on [flatpickr](https://flatpickr.js.org/).
-  If this component is included anywhere in an implementation, add `"node_modules/flatpickr/dist/flatpickr.css"` to the
-  `styles` array in `angular.json` to avoid issues.
-
+  When using this component, see the [migration notes](/release-notes/major9/09.21.0/migration.md) on how to upgrade.
+  
 * **Added new plugin actions to Documenten API and Zaken API plugin**
 
   New actions have been added to the Documenten API and Zaken API plugins: **Link uploaded document to zaak** and
@@ -94,11 +93,13 @@ This version has the following known issues:
   * It is not possible to create a new DMN table from scratch from the ui.
   * It is not possible to edit the key of a DMN table.
 
+
 * **Missing flatpickr dependency**
   
-  In front-end libraries verison 5.10.0, a new datepicker component has been added to `@valtimo/user-interface`. This
+  In the front-end libraries version 5.10.0, a new datepicker component has been added to `@valtimo/user-interface`. This
   component has a dependency on `flatpickr`, however, this was not included in the dependencies of
-  `@valtimo/user-interface`. This dependency will be included in a future version.
+  `@valtimo/user-interface`. 
+  This dependency has been added in [Valtimo frontend libraries 5.12.0](/release-notes/major9/09.23.0/valtimo-frontend-libraries.md).
 
-  To fix this for now, add the latest
-  version of `flatpickr` to the dependencies of the implementation by running `npm install flatpickr`.
+  To fix this for now, add the latest version of `flatpickr` to the dependencies of the implementation 
+  by running `npm install flatpickr`. Also see the [migration notes](/release-notes/major9/09.21.0/migration.md) on this topic.


### PR DESCRIPTION
For the date picker to work properly, besides installing flatpickr, which is discussed in the know issues, it is also necessary to add the style sheet to the styles array in angular.json. This is mentioned underneath the "new features" header, but as it can break the date picker, it should be moved to the migration notes.