### PR TITLE
tp-49377 Added process key to process started and ended audit events

### DIFF
--- a/release-notes/major9/09.24.0/valtimo-frontend-libraries.md
+++ b/release-notes/major9/09.24.0/valtimo-frontend-libraries.md
@@ -21,9 +21,13 @@ The following features were added:
 
 * **Valtimo list action callback**
 
-  A new `$event` parameter has been added to the action callback from the valtimo list component. 
+  A new `$event` parameter has been added to the action callback from the valtimo list component.
 
   You can use this parameter to call `$event.stopPropagation()` to stop the row click listener being triggered when using actions.
+
+* **Added process key to process started and ended audit events **
+
+  Process started and process ended events in the audit trail now show the associated process name.
 
 ## Bugfixes
 


### PR DESCRIPTION
Show which process was started or ended in the audit trail.

Front end: https://github.com/valtimo-platform/valtimo-frontend-libraries/pull/339
Back end: https://github.com/valtimo-platform/valtimo-backend-libraries/pull/485
Doc: https://github.com/valtimo-platform/valtimo-documentation/pull/251