### PR TITLE
Tp 49377 extend process state in audit trail 10.3.0

### DIFF
--- a/release-notes/major10/10.3.0/valtimo-frontend-libraries.md
+++ b/release-notes/major10/10.3.0/valtimo-frontend-libraries.md
@@ -8,6 +8,10 @@ The following features were added:
 
   When one of the search fields has been filled in and I press 'Enter', the search is executed
 
+* **Added process key to process started and ended audit events**
+
+  Process started and process ended events in the audit trail now show the associated process name.
+
 
 ## Bugfixes
 


### PR DESCRIPTION
Show which process was started or ended in the audit trail.

Front end: https://github.com/valtimo-platform/valtimo-frontend-libraries/pull/339
Back end: https://github.com/valtimo-platform/valtimo-backend-libraries/pull/485