### PR TITLE
Changed environment "file" to "file(s)"

### DIFF
--- a/release-notes/major10/10.0.0/valtimo-frontend-libraries.md
+++ b/release-notes/major10/10.0.0/valtimo-frontend-libraries.md
@@ -96,7 +96,7 @@ No new deprecations.
 
 This version has the following known issues:
 
-* **Viewing and editing DMN tables does not work if no 'featureToggles' object is present in the environment configuration**
+* **Viewing and editing DMN tables does not work if there is no 'featureToggles' object present in the environment configuration.**
 
   * Discovered in version 9.26.0
-  * As a workaround, an empty 'featureToggles' object can be added to the environment configuration.
+  * As a workaround, an empty 'featureToggles' object can be added to the environment configuration file(s).

--- a/release-notes/major10/10.0.1/valtimo-frontend-libraries.md
+++ b/release-notes/major10/10.0.1/valtimo-frontend-libraries.md
@@ -24,7 +24,7 @@ No new deprecations.
 
 This version has the following known issues:
 
-* **Viewing and editing DMN tables does not work if no 'featureToggles' object is present in the environment configuration**
+* **Viewing and editing DMN tables does not work if there is no 'featureToggles' object present in the environment configuration.**
 
   * Discovered in version 9.26.0
-  * As a workaround, an empty 'featureToggles' object can be added to the environment configuration.
+  * As a workaround, an empty 'featureToggles' object can be added to the environment configuration file(s).

--- a/release-notes/major10/10.1.0/valtimo-frontend-libraries.md
+++ b/release-notes/major10/10.1.0/valtimo-frontend-libraries.md
@@ -33,7 +33,7 @@ No new deprecations.
 
 This version has the following known issues:
 
-* **Viewing and editing DMN tables does not work if no 'featureToggles' object is present in the environment configuration**
+* **Viewing and editing DMN tables does not work if there is no 'featureToggles' object present in the environment configuration.**
 
   * Discovered in version 9.26.0
-  * As a workaround, an empty 'featureToggles' object can be added to the environment configuration.
+  * As a workaround, an empty 'featureToggles' object can be added to the environment configuration file(s).

--- a/release-notes/major10/10.2.0/valtimo-frontend-libraries.md
+++ b/release-notes/major10/10.2.0/valtimo-frontend-libraries.md
@@ -75,7 +75,7 @@ No new deprecations.
 
 This version has the following known issues:
 
-* **Viewing and editing DMN tables does not work if no 'featureToggles' object is present in the environment configuration**
+* **Viewing and editing DMN tables does not work if there is no 'featureToggles' object present in the environment configuration.**
 
   * Discovered in version 9.26.0
-  * As a workaround, an empty 'featureToggles' object can be added to the environment configuration.
+  * As a workaround, an empty 'featureToggles' object can be added to the environment configuration file(s).

--- a/release-notes/major9/09.18.0/valtimo-frontend-libraries.md
+++ b/release-notes/major9/09.18.0/valtimo-frontend-libraries.md
@@ -6,8 +6,8 @@ The following features were added:
 
 * **Show full name of user in the top bar**
 
-  The full name of the logged-in user can now be shown in the top bar. To enables this features, set
-  `showUserNameInTopBar` to true under `featureToggles` in your environment file.
+  The full name of the logged-in user can now be shown in the top bar. To enable this feature, set
+  `showUserNameInTopBar` to true under `featureToggles` in your environment file(s).
 
 * **Modify and delete plugin configurations**
 

--- a/release-notes/major9/09.26.0/valtimo-frontend-libraries.md
+++ b/release-notes/major9/09.26.0/valtimo-frontend-libraries.md
@@ -35,7 +35,7 @@ The following features were added:
 * **Disable unassigned case count feature toggle**
 
   It is now possible to disable showing the number of open cases in the menu. To do this, set `disableCaseCount` under
-  `featureToggles` in the environment file to `true`.
+  `featureToggles` in the environment file(s) to `true`.
 
 * **Hide assignee functionality based on the 'can have assignee' setting**
 
@@ -69,7 +69,7 @@ No new deprecations.
 
 This version has the following known issues:
 
-* **Viewing and editing DMN tables does not work if no 'featureToggles' object is present in the environment configuration**
+* **Viewing and editing DMN tables does not work if there is no 'featureToggles' object present in the environment configuration.**
 
   * Discovered in version 9.26.0
-  * As a workaround, an empty 'featureToggles' object can be added to the environment configuration.
+  * As a workaround, an empty 'featureToggles' object can be added to the environment configuration file(s).


### PR DESCRIPTION
Implying that if there are multiple environment files, it might be necessary to add featureToggles to all of them. I added this since it caused some confusion for me and other readers last week.