### PR TITLE
Added release notes and documentation about replacing deprecated 'carbon-components'

### DIFF
--- a/release-notes/major10/10.6.0/valtimo-frontend-libraries.md
+++ b/release-notes/major10/10.6.0/valtimo-frontend-libraries.md
@@ -31,6 +31,10 @@ The following features were added:
 
   The search functionality on the case list page has been improved to trigger a search every time, even if the search term has not changed. 
   This change enables users to search seamlessly, even when working with asynchronous data.
+
+* **Upgraded deprecated `carbon-components` package in `@valtimo/components` to `@carbon/styles`**
+
+  One of the Carbon Design System packages was deprecated and has been upgraded to the new package
 ## Bugfixes
 
 The following bugs were fixed:


### PR DESCRIPTION
Added release notes and documentation about replacing deprecated 'carbon-components' by the new '@carbon/styles'