### PR TITLE
Fixed typo in case-tabs documentation

### DIFF
--- a/using-valtimo/case/case-tabs.md
+++ b/using-valtimo/case/case-tabs.md
@@ -101,7 +101,7 @@ This can occur for one of two reasons:
 
 Case tabs can be auto-deployed from a JSON file at startup. This is useful to keep the case tab configuration identical
 across multiple environments. Case tabs are auto-deployed by scanning files on the classpath that end
-in `.case-tab.json`.
+in `.case-tabs.json`.
 
 ### Changesets
 


### PR DESCRIPTION
- Fixed typo in case-tabs documentation '.case-tab.json' > '.case-tabs.json'