### PR TITLE
Add note bugfix documentation

### DIFF
--- a/release-notes/major11/11.2.0/valtimo-frontend-libraries.md
+++ b/release-notes/major11/11.2.0/valtimo-frontend-libraries.md
@@ -89,6 +89,10 @@ The following bugs were fixed:
 
   The loading of the case notes could take a long time depending on the access control settings. This has been solved.
 
+* **Add note button not clickable on small windows**
+
+  The *Add note* button is now clickable even when resizing the window to a smaller size.
+
 ## Breaking changes
 
 The following breaking changes were introduced:


### PR DESCRIPTION
[[FE] Add note button not clickable when window is too small](https://ritense.tpondemand.com/entity/96974-fe-add-note-button-not-clickable)