### PR TITLE
Change java code blocks to kotlin

### DIFF
--- a/extending-valtimo/form-flow/whitelist-spring-bean.md
+++ b/extending-valtimo/form-flow/whitelist-spring-bean.md
@@ -12,18 +12,19 @@ the `@FormFlowBean` annotation.
 
 1. Ensure a bean for the class that should be whitelisted is provided.
 
-   ```java
+   ```kotlin
    @Bean
-   public SomethingService somethingService() {
-      return new somethingService();
+   
+   fun somethingService(): SomethingService{
+      return SomethingService()
    }
    ```
 
 2. At the top of the class, add the `@FormFlowBean` annotation.
 
-   ```java
+   ```kotlin
    @FormFlowBean
-   public class SomethingService {
+   class SomethingService {
       ...
    }
    ```

--- a/extending-valtimo/forms/creating-form-field-data-resolver.md
+++ b/extending-valtimo/forms/creating-form-field-data-resolver.md
@@ -28,18 +28,20 @@ the `varNames`) and the value is the value that needs to be loaded in the form.
 Below is an example of a `FormFieldDataResolver`. This example would be called for each form field where the `example` 
 prefix is used (e.g. `example:some-field`). 
 
-```java
-public class ExampleDataResolver implements FormFieldDataResolver {
-    private static final String PREFIX = "example";
-
-    @Override
-    public boolean supports(String externalFormFieldType) {
-        return externalFormFieldType.equals(PREFIX);
+```kotlin
+class ExampleDataResolver : FormFieldDataResolver {
+    
+    override fun supports(externalFormFieldType: String): Boolean {
+        return externalFormFieldType == PREFIX
     }
 
     @Override
-    public Map<String, Object> get(String documentDefinitionName, UUID documentId, String... varNames) {
+    override fun get(documentDefinitionName: String, documentId: UUID, vararg varNames: String): Map<String, Object> {
         // get values for all requested variables
+    }
+
+    companion object {
+        private const val PREFIX = "example"
     }
 }
 ```

--- a/extending-valtimo/integrate-spring-bean-in-process.md
+++ b/extending-valtimo/integrate-spring-bean-in-process.md
@@ -3,10 +3,10 @@
 It is possible to use custom code in your BPMN processes by referencing a [Spring bean](https://docs.spring.io/spring-framework/docs/current/reference/html/core.html)
 that contains the code you want to run. Any spring bean can be used in expressions by using the bean name.
  
-```java
+```kotlin
 @Component
-public class ExampleService {
-    public void helloWorld() {
+class ExampleService {
+    fun helloWorld() {
         // code goes here
     }
 }

--- a/extending-valtimo/process/whitelist-spring-bean.md
+++ b/extending-valtimo/process/whitelist-spring-bean.md
@@ -11,20 +11,20 @@ itself has to be whitelisted. This is done with the `@ProcessBean` annotation.
 
 1. Ensure a bean for the class that should be whitelisted is provided.
 
-   ```java
+   ```kotlin
    @Bean
-   public SomethingService somethingService() {
-      return new SomethingService();
+   fun somethingService(): SomethingService {
+      return SomethingService()
    }
    ```
 
 2. Add the `@ProcessBean` annotation.
 
-   ```java
+   ```kotlin
    @Bean
    @ProcessBean
-   public SomethingService somethingService() {
-      return new SomethingService();
+   fun somethingService(): SomethingService {
+      return SomethingService()
    }
    ```
 

--- a/extending-valtimo/test-utils-common/security-testing.md
+++ b/extending-valtimo/test-utils-common/security-testing.md
@@ -17,13 +17,13 @@ information can be found [here](/getting-started/modules/core/test-utils-common.
 Some custom code is needed to run the security smoke test. The code below shows how the `SecuritySmokeIntegrationTest`
 can be used to run the smoke test on a REST API endpoints in your application.
 
-```java
-public class MyProjectSecuritySmokeIntegrationTest extends SecuritySmokeIntegrationTest {
+```kotlin
+class MyProjectSecuritySmokeIntegrationTest : SecuritySmokeIntegrationTest {
 
-    public MyProjectSecuritySmokeIntegrationTest() {
-        super("com.mycompany.package", Set.of(
+    fun myProjectSecuritySmokeIntegrationTest() {
+        super("com.mycompany.package", setOf(
                 "GET /api/v1/open/exclude-this-endpoint/because-its-not-secured"
-        ));
+        ))
     }
 }
 ```

--- a/release-notes/major12/12.0.0/spring-boot3-migration.md
+++ b/release-notes/major12/12.0.0/spring-boot3-migration.md
@@ -25,15 +25,15 @@ Each chapter below describes the changes for the relevant framework or dependenc
   - When implementing the `HttpSecurityConfigurer`, this cannot be mixed with the replacement (`authorizeHttpRequests`).
 
 Before:
-```java
+```kotlin
 http.authorizeRequests()
-    .antMatchers(GET, "/api/v1/ping").permitAll();
+    .antMatchers(GET, "/api/v1/ping").permitAll()
 ```
 New:
-```java
-http.authorizeHttpRequests((requests) ->
+```kotlin
+http.authorizeHttpRequests { requests ->
     requests.requestMatchers(antMatcher(GET, "/api/v1/ping")).permitAll()
-);
+}
 ```
 - `WebSecurityConfigurerAdapter` has been removed.
   - Removed `CoreHttpSecurityConfigurerAdapter`. This has been replaced by `ValtimoCoreSecurityFactory`.

--- a/using-valtimo/process/process-beans/job-service.md
+++ b/using-valtimo/process/process-beans/job-service.md
@@ -6,9 +6,9 @@ This service is process bean that provides a way to manipulate jobs within the c
 
 Job service currently provides two methods that allow for an update on the timer due date in the current process.
 
-```java
-updateTimerDueDateByActivityId("2300-01-01T00:00:00Z","timer-id",execution);
-addOffsetInMillisToTimerDueDateByActivityId(1000,"timer-id",execution);
+```kotlin
+updateTimerDueDateByActivityId("2300-01-01T00:00:00Z","timer-id",execution)
+addOffsetInMillisToTimerDueDateByActivityId(1000,"timer-id",execution)
 ```
 - "updateTimerDueDateByActivityId" - allows changing the date by passing it as "String", in the ISO 8601 format , as the
   first parameter along with the timer event id and the current execution of the process as second and third parameters


### PR DESCRIPTION
Only things untouched are the migration notes for major 9. I do not think it makes sense to update these as implementations that go further back are more likely to use Java.