### PR TITLE
Added documentation for widget datasource fix

### DIFF
--- a/release-notes/major11/11.2.0/valtimo-frontend-libraries.md
+++ b/release-notes/major11/11.2.0/valtimo-frontend-libraries.md
@@ -125,6 +125,10 @@ The following bugs were fixed:
 
   The *Add note* button is now clickable even when resizing the window to a smaller size.
 
+* **Empty widget datasource**
+
+  The widget datasource dropdown is now populated with data.
+
 ## Breaking changes
 
 No breaking changes.


### PR DESCRIPTION
[[FE] Empty dropdown Widget datasource](https://ritense.tpondemand.com/entity/96875-fe-empty-dropdown-widget-datasource)