### PR TITLE
DevOps tracking release notes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+/release-notes/** @valtimo-platform/devops


### PR DESCRIPTION
See PR #597

DevOps has been tasked to track Valtimo release notes in order to be in the know when there are breaking changes in terms of supporting infrastructure.
To avoid missing release notes (happens easily through Slack) we'd like to receive an e-mail when there are new release notes available.
As such we've added DevOps as CODEOWNERS of release-notes files so they'll be notified when there are new release notes available.

To get notified of the release notes udpates right away this PR merges main already back into the RC.