### PR TITLE
Deprecation of modules

### DIFF
--- a/release-notes/major12/12.0.0/migration.md
+++ b/release-notes/major12/12.0.0/migration.md
@@ -259,4 +259,20 @@ This page describes how to update Valtimo from the previous version to the curre
   4. **Remove ChoicefieldModule**
 
     Remove any instances of ChoicefieldModule as it no longer exists. Services and models contained in that module are now a part of *@valtimo/components*.
+
+* **OpenZaakModule**
+
+  Scope: front-end
+
+  1. **ValtimoEmailExtension**
+
+    Remove any instance of the *valtimo-email-extension* that may be in use.
+
+  2. **Change import path of OpenZaakTypeLinkExtension and openZaakExtensionInitializer**
+
+    These entities can now be found in the *@valtimo/plugin* library. Adjust any import paths to use this instead of *@valtimo/open-zaak*.
+
+  3. **Remove OpenZaakModule**
+
+    Remove any instances of OpenZaakModule.
   

--- a/release-notes/major12/12.0.0/migration.md
+++ b/release-notes/major12/12.0.0/migration.md
@@ -235,13 +235,28 @@ This page describes how to update Valtimo from the previous version to the curre
         After completing the previous steps, run `npm i` in the root of your project to install all dependencies, and
         verify after that your project builds.
 
-* **Breaking change 2/Deprecation 2**
+* **ChoiceFieldsModule**
 
-  Scope: back-end/front-end
+  Scope: front-end
 
-  1. **Step1**
+  1. **Change the import path of ChoiceFieldService**
 
-      Description
-  2. **Step2**
+      The ChoiceFieldsService has now been moved into the *@valtimo/components* library. Adjust any import paths to use this instead of *@valtimo/choice-field* or *@valtimo/choicefield*.
 
-      Description
+  2. **Change import path of ChoiceField and ChoiceFieldValue**
+
+      These models can now be found in the *@valtimo/components* library. Adjust any import paths to use this instead of *@valtimo/choice-field* or *@valtimo/choicefield*.
+  
+  3. **Adjust method names**
+
+      A few methods from the former *@valtimo/choicefield* library now have their names changes:
+
+      * getChoiceFieldValuesPageByName -> queryValuesPage
+      * getChoiceFieldValueById -> getValue
+      * getChoiceFieldsPage -> queryPage
+      * getChoiceFields -> query
+
+  4. **Remove ChoicefieldModule**
+
+    Remove any instances of ChoicefieldModule as it no longer exists. Services and models contained in that module are now a part of *@valtimo/components*.
+  

--- a/release-notes/major12/12.0.0/valtimo-frontend-libraries.md
+++ b/release-notes/major12/12.0.0/valtimo-frontend-libraries.md
@@ -125,11 +125,7 @@ The following was deprecated:
 
 * **ConnectorManagementModule**
 
-  Connector-management has been deprecated and has been replaced by plugins.
-
-* **OpenZaak**
-
-  Open-zaak has been deprecated and the functionality still in use has already been moved to different modules.
+  Connector-management has been deprecated and replaced by plugins.
 
 Instructions on how to migrate to this version of Valtimo can be found [here](migration.md).
 

--- a/release-notes/major12/12.0.0/valtimo-frontend-libraries.md
+++ b/release-notes/major12/12.0.0/valtimo-frontend-libraries.md
@@ -97,7 +97,10 @@ The following bugs were fixed:
 
 The following breaking changes were introduced:
 
-* **Breaking change1**
+* **ChoiceFieldModule**
+
+  The ChoicefieldModule has been removed. Also the ChoiceFieldService and a few models have been moved to the *@valtimo/components* library.
+  Instructions on how to migrate to this version of Valtimo can be found [here](migration.md).
 
 * **Breaking change2**
 
@@ -107,12 +110,21 @@ Instructions on how to migrate to this version of Valtimo can be found [here](mi
 
 The following was deprecated:
 
-* **Deprecation1**
+* **ContactMomentModule**
 
-  X was deprecated and is replaced with Y.
-* **Deprecation2**
+  Contact-moment has been deprecated and will be replaced with plugins in the future.
 
-  X was deprecated and is replaced with Y.
+* **CustomerModule**
+
+  Customer has been deprecated and will be replaced with plugins in the future.
+
+* **ConnectorManagementModule**
+
+  Connector-management has been deprecated and has been replaced by plugins.
+
+* **OpenZaak**
+
+  Open-zaak has been deprecated and the functionality still in use has already been moved to different modules.
 
 Instructions on how to migrate to this version of Valtimo can be found [here](migration.md).
 

--- a/release-notes/major12/12.0.0/valtimo-frontend-libraries.md
+++ b/release-notes/major12/12.0.0/valtimo-frontend-libraries.md
@@ -102,6 +102,11 @@ The following breaking changes were introduced:
   The ChoicefieldModule has been removed. Also the ChoiceFieldService and a few models have been moved to the *@valtimo/components* library.
   Instructions on how to migrate to this version of Valtimo can be found [here](migration.md).
 
+* **OpenZaakModule**
+
+  The OpenZaakModule has been removed. EmailExtensionComponent has been removed altogether. The OpenZaakTypeLinkExtension has been moved to *@valtimo/plugin*
+  under the ZakenApiPluginModule. Instructions on how to migrate to this version of Valtimo can be found [here](migration.md).
+
 * **Breaking change2**
 
 Instructions on how to migrate to this version of Valtimo can be found [here](migration.md).


### PR DESCRIPTION
Modules deprecated:
- ContactMoment
- Customer
- ConnectorManagement

Modules removed:
- OpenZaak
- ViewConfigurator
- Choicefield

Modules merged:
- Choicefield and ChoiceField

Functionality moved:
- OpenZaakTypeLinkExtention for ZakenApiModule