### PR TITLE
Revert "Add documentation for initial ZGW sort, custom prefixes in value-path-selector, no-form-linked issue"

### DIFF
--- a/release-notes/12.x.x/12.14.2.md
+++ b/release-notes/12.x.x/12.14.2.md
@@ -11,10 +11,6 @@
 
 </details>
 
-## Bugfixes
-
-* Initial sorting on the ZGW Document list is now applied.
-
 ## For developers
 
 <details>
@@ -35,8 +31,6 @@
   * ZaakeigenschapDeleted
   * ZaakObjectCreated
 
-  These events are already available to external systems using the outbox module.
-
-* Value path selector: When passing an empty array of prefixes to the *value-path-selector* component, all custom value-resolver prefixes are available in the dropdown.
+These events are already available to external systems using the outbox module.
 
 </details>

--- a/release-notes/12.x.x/12.16.0.md
+++ b/release-notes/12.x.x/12.16.0.md
@@ -1,5 +1,0 @@
-# 12.16.0
-
-## Bugfixes
-
-* Supporting process modal now displays a loading spinner instead of the "No form linked" error while loading form data.

--- a/release-notes/12.x.x/12.16.1.md
+++ b/release-notes/12.x.x/12.16.1.md
@@ -1,5 +1,9 @@
 # 12.16.1
 
-## Bugfixes
+29 August 2025
 
-* Supporting process modal does not display the previously loaded form while loading the current form.
+Bug Fixes:&#x20;
+
+
+
+* [ ] fix for the supporting process modal showing an error or the previously loaded form before showing the correct data


### PR DESCRIPTION
.